### PR TITLE
upgrade torch version to 1.10.2, to get it to build again

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ docopt
 pyyaml
 protobuf==3.5.2
 grpcio==1.11.0
-torch==0.4.0
+torch==1.10.2
 pandas
 scipy
 ipykernel


### PR DESCRIPTION
The existing version of torch does not build. The error messages provided a list of compatible options and 1.10.2 was the most recent of those. This enables the setup instructions to finish successfully.